### PR TITLE
Disable platform automerge in default.json

### DIFF
--- a/default.json
+++ b/default.json
@@ -14,6 +14,7 @@
   "ignoreDeps": [],
   "ignorePaths": [],
   "osvVulnerabilityAlerts": true,
+  "platformAutomerge": false,
   "reviewersFromCodeOwners": true,
   "vulnerabilityAlerts": {
     "enabled": true


### PR DESCRIPTION
This prevents using Github's AutoMerge and on API-oriented auto-merge. This allows custom overrides to function properly and auto-deploy security updates.


---

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
